### PR TITLE
Use SquareSpace LESS compiler instead of less.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ This tool lets [Squarespace Developers](http://developers.squarespace.com) build
 - Support system search page
 
 
+### Prerequisites
+Squarespace LESS compiler [https://github.com/Squarespace/less-compiler]
+
+```shell
+git clone https://github.com/Squarespace/less-compiler.git
+cd squarespace-less
+gradle makeCli
+mv ./lessc /usr/local/bin/sqs-lessc
+sqs-lessc -h
+```
 ### Installation
 ```shell
 npm install -g node-squarespace-server


### PR DESCRIPTION
See https://github.com/Squarespace/less-compiler

Benefits:
 1. faster than lessjs
 2. supports squarespace-specific LESS features
   a. SquareSpace "tweaks" concept: http://developers.squarespace.com/style-editor/

   b. escaping variables to be used as selectors (see http://stackoverflow.com/questions/13553669/less-css-escape-interpolated-string-for-multiple-selectors) - see this example from `mobile-nav.less`

      ```less
    (~"@{mobileEl}") { ... }