### PR TITLE
Add --auth support for impersonating an authenticatedAccount state.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ sqs server --quiet
 # Open new tab in browser
 sqs server --open
 
+# Impersonate a Squarespace authenticateAccount session
+sqs server --auth
+
 # Bust local cache
 sqs buster
 ```
@@ -111,6 +114,11 @@ You will first be prompted with a login page. Enter your email and password for 
 
 ### Performance and Caching
 When you make initial requests to the pages of your site, they will likely be slow. Imagine why. For every page the module needs to request both full `html` (for headers and footers parsing) and `json` (for rendering). That's 2 requests. For every `squarespace:query` and `squarespace:block-field` tag the module must make another request. Well, that's a lot of requests for sure. Luckily, the module caches everything via a `.sqs-cache` directory in your template root. This is good to speed things up. But, sometimes you want to pull down the latest and greatest content from your site. You can do this by hitting any page with a `?nocache` query string. To blow away your entire cache you can either delete it manually or use the `sqs buster` command.
+
+
+
+### Squarespace authenticatedAccount JSON
+When logged in to a Squarespace website, Squarespace adds an `authenticatedAccount` JSON object. This object is useful for creating conditional template code that renders only when logged in to Squarespace's backend config. This is common for automatically swapping out minified JavaScript links, Squarespace script comboing, or anything you want hidden to the public but displayed in the backend. Using the node-squarespace-server `--auth` arugment will allow you to move between `authenticatedAccount` states.
 
 
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "title": "Node Squarespace Server",
   "name": "node-squarespace-server",
   "description": "A local Squarespace development server in node.js for folks using the developer platform.",
-  "version": "0.5.3",
+  "version": "0.5.31",
   "homepage": "https://github.com/NodeSquarespace/node-squarespace-server",
   "readmeFilename": "README.md",
   "contributors": [

--- a/squarespace-server.js
+++ b/squarespace-server.js
@@ -692,6 +692,11 @@ processArguments = function ( args, cb ) {
         serverConfig.open = true;
     }
 
+    // Set Squarespace authentication impersonation status.
+    if ( flags.auth ) {
+        serverConfig.auth = true;
+    }
+
     // Order of operations
     if ( flags.version ) {
         printVersion();

--- a/squarespace-template.js
+++ b/squarespace-template.js
@@ -445,7 +445,7 @@ replaceSQSScripts = function () {
  * @param {object} qrs Querystring mapping
  * @param {object} pageJson JSON data for page
  * @param {string} pageHtml HTML for page
- * @param {function} clalback Fired when done
+ * @param {function} callback Fired when done
  * @public
  *
  */
@@ -465,7 +465,7 @@ renderTemplate = function ( qrs, pageJson, pageHtml, callback ) {
     // Unique page JSON property for sandbox dev mode
     pageJson.nodeServer = true;
 
-    // Remote authenticatedAccount JSON key from rendered template during CLI auth arugment.
+    // Remove authenticatedAccount JSON key from rendered template during CLI auth arugment.
     if ( config.server.auth ) {
         delete pageJson.authenticatedAccount;
     }

--- a/squarespace-template.js
+++ b/squarespace-template.js
@@ -465,6 +465,11 @@ renderTemplate = function ( qrs, pageJson, pageHtml, callback ) {
     // Unique page JSON property for sandbox dev mode
     pageJson.nodeServer = true;
 
+    // Remote authenticatedAccount JSON key from rendered template during CLI auth arugment.
+    if ( config.server.auth ) {
+        delete pageJson.authenticatedAccount;
+    }
+
     // Create {squarespace-headers} / {squarespace-footers}
     setHeaderFooterTokens( pageJson, pageHtml );
 
@@ -571,7 +576,7 @@ renderTemplate = function ( qrs, pageJson, pageHtml, callback ) {
             callback( finalRender );
         });
     }
-    
+
     function handleProcessed() {
         processedQueries++;
 
@@ -1384,7 +1389,7 @@ replaceBlockFields = function ( rendered, qrs, callback ) {
                         } else {
                             getBlocks();
                         }
-                        
+
                     } else {
                         getWidget();
                     }


### PR DESCRIPTION
Thought it would be useful to users to move between Squarespace `authenticatedAccount` states using the CLI API. When the `--auth` argument is passed to the CLI, this update simply removes the JSON object during template rendering, while keeping it in the cache. Fixes #187.